### PR TITLE
Fix concurrent exception with Sidebar#addViewers

### DIFF
--- a/src/main/java/me/catcoder/sidebar/Sidebar.java
+++ b/src/main/java/me/catcoder/sidebar/Sidebar.java
@@ -394,14 +394,15 @@ public class Sidebar<R> {
         if (!viewers.contains(player.getUniqueId())) {
             objective.create(player);
 
-            for (SidebarLine<R> line : lines) {
-                line.createTeam(player, objective.getName());
+            synchronized (lines) {
+                for (SidebarLine<R> line : lines) {
+                    line.createTeam(player, objective.getName());
+                }
             }
 
             objective.display(player);
 
             viewers.add(player.getUniqueId());
-
         }
     }
 


### PR DESCRIPTION
This pull request should be a fix for concurrent exception occuring on adding viewer to newly created scoreboard.
```
[12:07:12] [Craft Scheduler Thread - 719 - auroramc-scrubby/WARN]: [auroramc-scrubby] Plugin auroramc-scrubby v1.0-SNAPSHOT generated an exception while executing task 46
java.util.ConcurrentModificationException: null
	at java.util.ArrayList$Itr.checkForComodification(ArrayList.java:1013) ~[?:?]
	at java.util.ArrayList$Itr.next(ArrayList.java:967) ~[?:?]
	at me.catcoder.sidebar.Sidebar.addViewer(Sidebar.java:397) ~[auroramc-scrubby-1.0-SNAPSHOT.jar:?]
	at pl.auroramc.scrubby.sidebar.ProtocolSidebarRenderer.render(ProtocolSidebarRenderer.java:38) ~[auroramc-scrubby-1.0-SNAPSHOT.jar:?]
	at pl.auroramc.scrubby.sidebar.SidebarRenderingTask.run(SidebarRenderingTask.java:18) ~[auroramc-scrubby-1.0-SNAPSHOT.jar:?]
	at org.bukkit.craftbukkit.v1_20_R2.scheduler.CraftTask.run(CraftTask.java:101) ~[purpur-1.20.2.jar:git-Purpur-2083]
	at org.bukkit.craftbukkit.v1_20_R2.scheduler.CraftAsyncTask.run(CraftAsyncTask.java:57) ~[purpur-1.20.2.jar:git-Purpur-2083]
	at com.destroystokyo.paper.ServerSchedulerReportingWrapper.run(ServerSchedulerReportingWrapper.java:22) ~[purpur-1.20.2.jar:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
	at java.lang.Thread.run(Thread.java:840) ~[?:?]
```