### PR TITLE
ConditionalTitle and ConditionalLine fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 * [Basic usage](#basic-usage)
 * [Conditional lines](#conditional-lines)
 * [Conditional titles](#conditional-titles)
+* [Line limits](#line-limits)
 * [Score number formatting](#score-number-formatting)
 * [Sidebar title animations](#sidebar-title-animations)
 * [Sidebar Pager](#sidebar-pager)
@@ -170,7 +171,8 @@ sidebar.setTitle(player -> isVip(player) ? vipTitle : normalTitle);
 ```
 
 For a list of conditions, use `ConditionalTitle`. Conditions are checked in the order they
-were added and the first match wins; `otherwise` is used when nothing matches:
+were added and the first match wins. `otherwise` is required, because a player matching no
+condition has to be given some title:
 
 ```java
 import static me.catcoder.sidebar.util.PlayerPredicates.*;
@@ -186,9 +188,11 @@ sidebar.setTitle(ConditionalTitle.<Component>create()
 Client versions are resolved through ViaVersion. Without ViaVersion installed, every player
 reports the server version.
 
-The title is resolved when a player is added as a viewer. If your conditions depend on state
-that changes later (rank, world, game phase), call `sidebar.updateTitle()` to re-evaluate it
-for all current viewers.
+The title is resolved for every objective packet, so it is re-evaluated whenever a player is
+added as a viewer. There is no automatic tick: if your conditions depend on state that changes
+later (rank, world, game phase), call `sidebar.updateTitle()`.
+
+`setTitle` snapshots the conditions, so mutating the `ConditionalTitle` afterwards has no effect.
 
 `PlayerPredicates` also works with [conditional lines](#conditional-lines):
 
@@ -197,6 +201,23 @@ sidebar.addConditionalLine(player -> Component.text("1.8 only"), clientVersionAt
 ```
 
 Setting a plain title again with `setTitle(component)` clears the conditional title.
+
+To read the title as a specific player sees it, use `getObjective().getDisplayName(player)`.
+The no-argument `getDisplayName()` returns the static title only.
+
+## Line limits
+
+A sidebar has two different limits:
+
+* **`Sidebar.MAX_VISIBLE_LINES` (15)** how many lines the client renders. Beyond this it shows
+  the highest scored lines and drops the rest.
+* **`Sidebar.MAX_LINES_COUNT` (22)** how many lines a sidebar can hold. Every line permanently
+  owns one unique invisible team entry, visible or not, and that alphabet runs out at 22.
+
+Since conditional lines are hidden per player, a sidebar may hold more lines than the client
+renders, as long as no player ever sees more than 15 at once. `addLine` therefore only rejects
+what cannot work: a 23rd line of any kind, or a 16th line without a display condition. If a
+player does end up with more than 15 visible lines, a warning is logged once per sidebar.
 
 ## Sidebar Title Animations
 

--- a/src/main/java/me/catcoder/sidebar/ConditionalTitle.java
+++ b/src/main/java/me/catcoder/sidebar/ConditionalTitle.java
@@ -91,7 +91,20 @@ public final class ConditionalTitle<R> {
     }
 
     /**
+     * Whether a fallback title was set via {@link #otherwise}.
+     * Without one, {@link #toUpdater()} throws for a player matching no condition.
+     *
+     * @return true if a fallback title is set
+     */
+    public boolean hasFallback() {
+        return fallback != null;
+    }
+
+    /**
      * Converts this conditional title to a per-player title updater.
+     * <p>
+     * The conditions are snapshot, so mutating this instance afterward does not
+     * affect the returned updater.
      *
      * @return the title updater
      */

--- a/src/main/java/me/catcoder/sidebar/LineIndexAllocator.java
+++ b/src/main/java/me/catcoder/sidebar/LineIndexAllocator.java
@@ -1,0 +1,48 @@
+package me.catcoder.sidebar;
+
+import com.google.common.base.Preconditions;
+
+import java.util.BitSet;
+
+/**
+ * Hands out the line slots of a sidebar, lowest free slot first.
+ * <p>
+ * A slot decides both the team name and the invisible team entry of a line, so two live lines
+ * must never share one. Not thread safe, {@link Sidebar} holds its lines lock.
+ */
+final class LineIndexAllocator {
+
+    private final BitSet used;
+    private final int capacity;
+
+    LineIndexAllocator(int capacity) {
+        Preconditions.checkArgument(capacity > 0, "Capacity must be positive");
+
+        this.capacity = capacity;
+        this.used = new BitSet(capacity);
+    }
+
+    int allocate() {
+        int index = used.nextClearBit(0);
+
+        Preconditions.checkState(index < capacity,
+                "No free line slot available, all %s are in use", capacity);
+
+        used.set(index);
+        return index;
+    }
+
+    void release(int index) {
+        Preconditions.checkElementIndex(index, capacity, "Line slot");
+
+        used.clear(index);
+    }
+
+    void releaseAll() {
+        used.clear();
+    }
+
+    int allocatedCount() {
+        return used.cardinality();
+    }
+}

--- a/src/main/java/me/catcoder/sidebar/ScoreboardObjective.java
+++ b/src/main/java/me/catcoder/sidebar/ScoreboardObjective.java
@@ -3,6 +3,7 @@ package me.catcoder.sidebar;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import io.netty.buffer.ByteBuf;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NonNull;
 import me.catcoder.sidebar.protocol.ChannelInjector;
@@ -47,6 +48,7 @@ public class ScoreboardObjective<R> {
      * Resolves the title per player. When {@code null}, the static {@link #displayName} is used.
      * Volatile because it is read from the async broadcast threads.
      */
+    @Getter(AccessLevel.NONE)
     private volatile ThrowingFunction<Player, R, Throwable> displayNameUpdater;
 
     ScoreboardObjective(@NonNull String name,
@@ -68,6 +70,19 @@ public class ScoreboardObjective<R> {
 
     void setDisplayNameUpdater(@NonNull ThrowingFunction<Player, R, Throwable> displayNameUpdater) {
         this.displayNameUpdater = displayNameUpdater;
+    }
+
+    /**
+     * Resolves the title as it is shown to the given player.
+     * Unlike {@link #getDisplayName()}, this honours a per-player or conditional title.
+     *
+     * @param player target player
+     * @return the title shown to that player
+     */
+    @SneakyThrows
+    public R getDisplayName(@NonNull Player player) {
+        ThrowingFunction<Player, R, Throwable> updater = displayNameUpdater;
+        return updater != null ? updater.apply(player) : displayName;
     }
 
     void updateValue(@NonNull Player player) {
@@ -128,7 +143,7 @@ public class ScoreboardObjective<R> {
 
         if (mode == ADD_OBJECTIVE || mode == UPDATE_VALUE) {
             // resolved per player, so conditional titles can differ between viewers
-            R title = displayNameUpdater != null ? displayNameUpdater.apply(player) : displayName;
+            R title = getDisplayName(player);
 
             String legacyText = textProvider.asLegacyMessage(player, title);
             // Since 1.13 characters limit for display name was removed

--- a/src/main/java/me/catcoder/sidebar/Sidebar.java
+++ b/src/main/java/me/catcoder/sidebar/Sidebar.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 import lombok.NonNull;
 import lombok.SneakyThrows;
 import lombok.experimental.FieldDefaults;
+import me.catcoder.sidebar.protocol.ScoreboardPackets;
 import me.catcoder.sidebar.text.TextIterator;
 import me.catcoder.sidebar.text.TextProvider;
 import me.catcoder.sidebar.util.RandomString;
@@ -22,6 +23,7 @@ import org.bukkit.plugin.Plugin;
 import org.bukkit.scheduler.BukkitTask;
 
 import java.util.*;
+import java.util.logging.Level;
 
 /**
  * Represents a sidebar.
@@ -34,10 +36,14 @@ import java.util.*;
 public class Sidebar<R> {
 
     private static final String OBJECTIVE_PREFIX = "PS-";
-    private static final int MAX_LINES_COUNT = 15;
+    public static final int MAX_VISIBLE_LINES = 15;
+    public static final int MAX_LINES_COUNT = ScoreboardPackets.COLORS.length;
 
     private final Set<UUID> viewers = Collections.synchronizedSet(new HashSet<>());
     private final List<SidebarLine<R>> lines = new ArrayList<>();
+    private final LineIndexAllocator indexAllocator = new LineIndexAllocator(MAX_LINES_COUNT);
+
+    private boolean warnedAboutOverflow;
     @Getter
     private final ScoreboardObjective<R> objective;
 
@@ -121,8 +127,9 @@ public class Sidebar<R> {
      * The updater is invoked for each viewer separately, so the title
      * may differ between players.
      * <p>
-     * The title is resolved when a player is added as a viewer. Call
-     * {@link #updateTitle()} to re-evaluate it for all current viewers.
+     * The title is resolved for every objective packet sent to a player, so it is
+     * re-evaluated whenever a player is added as a viewer. Call {@link #updateTitle()}
+     * to re-evaluate it for all current viewers.
      *
      * @param updater - the function that produces the title for a player
      */
@@ -136,13 +143,17 @@ public class Sidebar<R> {
 
     /**
      * Update the title of the sidebar with a title chosen by conditions.
-     * <p>
-     * The title is resolved when a player is added as a viewer. Call
-     * {@link #updateTitle()} to re-evaluate it for all current viewers.
+     * Resolved per player like {@link #setTitle(ThrowingFunction)}, and the conditions are
+     * snapshotted, so mutating {@code title} afterward has no effect.
      *
-     * @param title - the conditional title
+     * @param title - the conditional title, requires a {@link ConditionalTitle#otherwise} title
      */
     public void setTitle(@NonNull ConditionalTitle<R> title) {
+        // fail here rather than while building a packet for the first player that matches nothing
+        Preconditions.checkArgument(title.hasFallback(),
+                "ConditionalTitle requires an otherwise(...) title, "
+                        + "players matching no condition cannot be given a title");
+
         setTitle(title.toUpdater());
     }
 
@@ -183,6 +194,9 @@ public class Sidebar<R> {
      */
     public void shiftLine(SidebarLine<R> line, int offset) {
         synchronized (lines) {
+            Preconditions.checkArgument(lines.contains(line), "Line %s is not a part of this sidebar", line);
+            Preconditions.checkPositionIndex(offset, lines.size() - 1, "Line offset");
+
             lines.remove(line);
             lines.add(offset, line);
         }
@@ -275,7 +289,7 @@ public class Sidebar<R> {
      * @return SidebarLine instance
      */
     public SidebarLine<R> addUpdatableLine(@NonNull ThrowingFunction<Player, R, Throwable> updater) {
-        return addLine(updater, false, x -> true);
+        return addLine(updater, false, SidebarLine.ALWAYS_VISIBLE);
     }
 
     /**
@@ -295,7 +309,7 @@ public class Sidebar<R> {
      * @return SidebarLine instance
      */
     public SidebarLine<R> addLine(@NonNull R text) {
-        return addLine(x -> text, true, x -> true);
+        return addLine(x -> text, true, SidebarLine.ALWAYS_VISIBLE);
     }
 
     /**
@@ -310,16 +324,37 @@ public class Sidebar<R> {
     private SidebarLine<R> addLine(@NonNull ThrowingFunction<Player, R, Throwable> updater, boolean staticText,
                                    @NonNull ThrowingPredicate<Player, Throwable> predicate) {
         synchronized (lines) {
-            Preconditions.checkArgument(
-                    lines.size() <= MAX_LINES_COUNT, "Cannot add more than %s lines to a sidebar", MAX_LINES_COUNT);
+            Preconditions.checkArgument(lines.size() < MAX_LINES_COUNT,
+                    "Cannot add more than %s lines to a sidebar", MAX_LINES_COUNT);
+
+            if (predicate == SidebarLine.ALWAYS_VISIBLE) {
+                Preconditions.checkArgument(unconditionalLineCount() < MAX_VISIBLE_LINES,
+                        "Cannot add more than %s always visible lines to a sidebar, the client renders "
+                                + "at most that many. Use addConditionalLine(..) for lines that are not "
+                                + "always shown.", MAX_VISIBLE_LINES);
+            }
+
+            int index = indexAllocator.allocate();
 
             SidebarLine<R> line = new SidebarLine<>(
-                    updater, objective.getName() + lines.size(),
-                    staticText, lines.size(), textProvider, predicate);
+                    updater, objective.getName() + index,
+                    staticText, index, textProvider, predicate);
 
             lines.add(line);
             return line;
         }
+    }
+
+    private int unconditionalLineCount() {
+        int count = 0;
+
+        for (SidebarLine<R> line : lines) {
+            if (!line.isConditional()) {
+                count++;
+            }
+        }
+
+        return count;
     }
 
     /**
@@ -329,7 +364,13 @@ public class Sidebar<R> {
      */
     public void removeLine(@NonNull SidebarLine<R> line) {
         synchronized (lines) {
-            if (lines.remove(line) && line.getScore() != -1) {
+            if (!lines.remove(line)) {
+                return;
+            }
+
+            indexAllocator.release(line.getIndex());
+
+            if (line.getScore() != -1) {
                 broadcast(p -> line.removeTeam(p, objective.getName()));
                 updateAllLines();
             }
@@ -377,30 +418,82 @@ public class Sidebar<R> {
 
     /**
      * Update all dynamic lines of the sidebar.
-     * Except lines with their own update task. (see {@link SidebarLine#updatePeriodically(long, long, Sidebar)})
+     * Lines with their own update task keep their text, only their score is sent.
+     * (see {@link SidebarLine#updatePeriodically(long, long, Sidebar)})
      */
     public void updateAllLines() {
         synchronized (lines) {
-            int index = lines.size();
+            LineAction[] actions = new LineAction[lines.size()];
+            int score = lines.size();
 
-            for (SidebarLine<R> line : lines) {
+            for (int i = 0; i < lines.size(); i++) {
+                SidebarLine<R> line = lines.get(i);
+
                 // if line is not created yet
                 if (line.getScore() == -1) {
-                    line.setScore(index--);
-                    broadcast(p -> line.createTeam(p, objective.getName()));
+                    line.setScore(score--);
+                    actions[i] = LineAction.CREATE;
                     continue;
                 }
 
                 if (line.updateTask != null && !line.updateTask.isCancelled()) {
-                    // Don't update the line if it's already has its own update task
+                    // its own task owns the text, but the score is positional and has to follow
+                    line.setScore(score--);
+                    actions[i] = LineAction.SCORE_ONLY;
                     continue;
                 }
 
-                line.setScore(index--);
-
-                broadcast(p -> line.updateTeam(p, objective.getName()));
+                line.setScore(score--);
+                actions[i] = LineAction.UPDATE;
             }
+
+            broadcast(player -> {
+                int visible = 0;
+
+                for (int i = 0; i < actions.length; i++) {
+                    SidebarLine<R> line = lines.get(i);
+                    boolean shown;
+
+                    switch (actions[i]) {
+                        case CREATE:
+                            shown = line.createTeam(player, objective.getName());
+                            break;
+                        case UPDATE:
+                            shown = line.updateTeam(player, objective.getName());
+                            break;
+                        default:
+                            shown = line.updateScore(player, objective.getName());
+                            break;
+                    }
+
+                    if (shown) {
+                        visible++;
+                    }
+                }
+
+                warnOnOverflow(player, visible);
+            });
         }
+    }
+
+    private void warnOnOverflow(@NonNull Player player, int visible) {
+        if (warnedAboutOverflow || visible <= MAX_VISIBLE_LINES) {
+            return;
+        }
+
+        warnedAboutOverflow = true;
+
+        plugin.getLogger().warning(String.format(
+                "Sidebar %s has %s lines visible for %s, but the client renders at most %s. "
+                        + "The lowest scored lines will not be shown. "
+                        + "This is logged once per sidebar.",
+                objective.getName(), visible, player.getName(), MAX_VISIBLE_LINES));
+    }
+
+    private enum LineAction {
+        CREATE,
+        UPDATE,
+        SCORE_ONLY
     }
 
     /**
@@ -440,6 +533,7 @@ public class Sidebar<R> {
 
         synchronized (lines) {
             lines.clear();
+            indexAllocator.releaseAll();
         }
 
         tasks.clear();
@@ -457,15 +551,35 @@ public class Sidebar<R> {
             objective.create(player);
 
             synchronized (lines) {
-                for (SidebarLine<R> line : lines) {
-                    line.createTeam(player, objective.getName());
+                if (hasUnscoredLines()) {
+                    updateAllLines();
                 }
+
+                int visible = 0;
+
+                for (SidebarLine<R> line : lines) {
+                    if (line.createTeam(player, objective.getName())) {
+                        visible++;
+                    }
+                }
+
+                warnOnOverflow(player, visible);
             }
 
             objective.display(player);
 
             viewers.add(player.getUniqueId());
         }
+    }
+
+    private boolean hasUnscoredLines() {
+        for (SidebarLine<R> line : lines) {
+            if (line.getScore() == -1) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -520,8 +634,8 @@ public class Sidebar<R> {
                 try {
                     consumer.accept(player);
                 } catch (Throwable e) {
-                    throw new RuntimeException("An error occurred while updating sidebar for player: " + player.getName(),
-                            e);
+                    plugin.getLogger().log(Level.SEVERE,
+                            "An error occurred while updating sidebar for player: " + player.getName(), e);
                 }
             }
         }

--- a/src/main/java/me/catcoder/sidebar/SidebarLine.java
+++ b/src/main/java/me/catcoder/sidebar/SidebarLine.java
@@ -18,6 +18,8 @@ import org.bukkit.entity.Player;
 @ToString
 public class SidebarLine<R> {
 
+    static final ThrowingPredicate<Player, Throwable> ALWAYS_VISIBLE = player -> true;
+
     private final String teamName;
 
     @Setter(AccessLevel.PACKAGE)
@@ -98,6 +100,28 @@ public class SidebarLine<R> {
     }
 
     /**
+     * Whether this line has a display condition, i.e. whether it may be hidden from some players.
+     *
+     * @return true if the line has a display condition
+     */
+    public boolean isConditional() {
+        return displayCondition != ALWAYS_VISIBLE;
+    }
+
+    /**
+     * Sends only the score of this line, leaving its text alone.
+     */
+    boolean updateScore(@NonNull Player player, @NonNull String objective) throws Throwable {
+        boolean visible = displayCondition.test(player);
+
+        sendPacket(player, ScoreboardPackets.createScorePacket(
+                player, visible ? 0 : 1, objective, score, index, textProvider,
+                scoreNumberFormat, visible ? scoreNumberFormatter : null));
+
+        return visible;
+    }
+
+    /**
      * Sets updater for this line. Updater is a function that takes player as an argument and returns
      * text that will be displayed for this player.
      *
@@ -118,7 +142,7 @@ public class SidebarLine<R> {
         this.updater = player -> updater.get();
     }
 
-    void updateTeam(@NonNull Player player, @NonNull String objective) throws Throwable {
+    boolean updateTeam(@NonNull Player player, @NonNull String objective) throws Throwable {
         boolean visible = displayCondition.test(player);
 
         if (!isStaticText() && visible) {
@@ -132,11 +156,13 @@ public class SidebarLine<R> {
             // if player doesn't meet display condition, remove score
             sendPacket(player, ScoreboardPackets.createScorePacket(
                     player, 1, objective, score, index, textProvider, scoreNumberFormat, null));
-            return;
+            return false;
         }
 
         sendPacket(player, ScoreboardPackets.createScorePacket(
                 player, 0, objective, score, index, textProvider, scoreNumberFormat, scoreNumberFormatter));
+
+        return true;
     }
 
     void removeTeam(@NonNull Player player, @NonNull String objective) {
@@ -147,7 +173,7 @@ public class SidebarLine<R> {
                 player, null, textProvider));
     }
 
-    void createTeam(@NonNull Player player, @NonNull String objective) throws Throwable {
+    boolean createTeam(@NonNull Player player, @NonNull String objective) throws Throwable {
         boolean visible = displayCondition.test(player);
 
         R text = visible ? updater.apply(player) : textProvider.emptyMessage();
@@ -159,6 +185,8 @@ public class SidebarLine<R> {
             sendPacket(player, ScoreboardPackets.createScorePacket(
                     player, 0, objective, score, index, textProvider, scoreNumberFormat, scoreNumberFormatter));
         }
+
+        return visible;
     }
 
     @SneakyThrows

--- a/src/main/java/me/catcoder/sidebar/util/version/VersionUtil.java
+++ b/src/main/java/me/catcoder/sidebar/util/version/VersionUtil.java
@@ -1,9 +1,10 @@
 package me.catcoder.sidebar.util.version;
 
 import com.viaversion.viaversion.ViaVersionPlugin;
+import com.viaversion.viaversion.api.ViaAPI;
 import lombok.NonNull;
 import org.bukkit.Bukkit;
-import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.plugin.Plugin;
 
 import java.util.UUID;
 
@@ -18,7 +19,35 @@ public final class VersionUtil {
     }
 
     public static int getPlayerVersion(@NonNull UUID id) {
-        boolean isVia = Bukkit.getPluginManager().isPluginEnabled("ViaVersion");
-        return isVia ? JavaPlugin.getPlugin(ViaVersionPlugin.class).getApi().getPlayerProtocolVersion(id).getVersion() : SERVER_VERSION;
+        Plugin plugin = Bukkit.getPluginManager().getPlugin("ViaVersion");
+
+        if (plugin == null || !plugin.isEnabled()) {
+            return SERVER_VERSION;
+        }
+
+        return ViaLookup.playerVersion(plugin, id);
+    }
+
+    private static final class ViaLookup {
+
+        private static volatile ViaLookup current;
+
+        private final Plugin plugin;
+        private final ViaAPI<?> api;
+
+        private ViaLookup(Plugin plugin, ViaAPI<?> api) {
+            this.plugin = plugin;
+            this.api = api;
+        }
+
+        static int playerVersion(Plugin plugin, UUID id) {
+            ViaLookup lookup = current;
+
+            if (lookup == null || lookup.plugin != plugin) {
+                current = lookup = new ViaLookup(plugin, ((ViaVersionPlugin) plugin).getApi());
+            }
+
+            return lookup.api.getPlayerProtocolVersion(id).getVersion();
+        }
     }
 }

--- a/src/test/java/me/catcoder/sidebar/ConditionalTitleTest.java
+++ b/src/test/java/me/catcoder/sidebar/ConditionalTitleTest.java
@@ -6,7 +6,9 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class ConditionalTitleTest {
 
@@ -79,5 +81,24 @@ public class ConditionalTitleTest {
         title.when(p -> true, "added later");
 
         assertEquals("fallback", updater.apply(player("alice")));
+    }
+
+    @Test
+    public void testHasFallbackReflectsOtherwise() {
+        assertFalse(ConditionalTitle.<String>create()
+                .when(p -> true, "titleA")
+                .hasFallback());
+
+        assertTrue(ConditionalTitle.<String>create()
+                .when(p -> true, "titleA")
+                .otherwise("fallback")
+                .hasFallback());
+    }
+
+    @Test
+    public void testHasFallbackWithFunctionForm() {
+        assertTrue(ConditionalTitle.<String>create()
+                .otherwise(p -> "fallback " + p.getName())
+                .hasFallback());
     }
 }

--- a/src/test/java/me/catcoder/sidebar/LineIndexAllocatorTest.java
+++ b/src/test/java/me/catcoder/sidebar/LineIndexAllocatorTest.java
@@ -1,0 +1,67 @@
+package me.catcoder.sidebar;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+public class LineIndexAllocatorTest {
+
+    @Test
+    public void testAllocatesSequentially() {
+        LineIndexAllocator allocator = new LineIndexAllocator(4);
+
+        assertEquals(0, allocator.allocate());
+        assertEquals(1, allocator.allocate());
+        assertEquals(2, allocator.allocate());
+        assertEquals(3, allocator.allocatedCount());
+    }
+
+    @Test
+    public void testReusesReleasedSlot() {
+        LineIndexAllocator allocator = new LineIndexAllocator(4);
+
+        allocator.allocate(); // 0
+        allocator.allocate(); // 1
+        allocator.allocate(); // 2
+
+        allocator.release(1);
+
+        assertEquals(1, allocator.allocate());
+        assertEquals(3, allocator.allocate());
+    }
+
+    @Test
+    public void testThrowsWhenExhausted() {
+        LineIndexAllocator allocator = new LineIndexAllocator(2);
+
+        allocator.allocate();
+        allocator.allocate();
+
+        assertThrows(IllegalStateException.class, allocator::allocate);
+    }
+
+    @Test
+    public void testReleaseAllFreesEverything() {
+        LineIndexAllocator allocator = new LineIndexAllocator(3);
+
+        allocator.allocate();
+        allocator.allocate();
+        allocator.releaseAll();
+
+        assertEquals(0, allocator.allocatedCount());
+        assertEquals(0, allocator.allocate());
+    }
+
+    @Test
+    public void testRejectsOutOfRangeRelease() {
+        LineIndexAllocator allocator = new LineIndexAllocator(2);
+
+        assertThrows(IndexOutOfBoundsException.class, () -> allocator.release(2));
+    }
+
+    @Test
+    public void testRejectsNonPositiveCapacity() {
+        assertThrows(IllegalArgumentException.class, () -> new LineIndexAllocator(0));
+    }
+}

--- a/src/test/java/me/catcoder/sidebar/ScoreboardObjectiveTitleTest.java
+++ b/src/test/java/me/catcoder/sidebar/ScoreboardObjectiveTitleTest.java
@@ -1,0 +1,76 @@
+package me.catcoder.sidebar;
+
+import me.catcoder.sidebar.text.TextProvider;
+import org.bukkit.entity.Player;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.assertEquals;
+
+public class ScoreboardObjectiveTitleTest {
+
+    private static final TextProvider<String> TEXT_PROVIDER = new TextProvider<String>() {
+        @Override
+        public String asJsonMessage(Player player, String component) {
+            return component;
+        }
+
+        @Override
+        public String asLegacyMessage(Player player, String component) {
+            return component;
+        }
+
+        @Override
+        public String emptyMessage() {
+            return "";
+        }
+
+        @Override
+        public String fromLegacyMessage(String message) {
+            return message;
+        }
+    };
+
+    private static Player player(String name) {
+        Player player = Mockito.mock(Player.class);
+        Mockito.when(player.getName()).thenReturn(name);
+        return player;
+    }
+
+    private static ScoreboardObjective<String> objective() {
+        return new ScoreboardObjective<>("PS-test", "static", TEXT_PROVIDER);
+    }
+
+    @Test
+    public void testResolvesStaticTitleWithoutUpdater() {
+        assertEquals("static", objective().getDisplayName(player("alice")));
+    }
+
+    @Test
+    public void testResolvesUpdaterPerPlayer() {
+        ScoreboardObjective<String> objective = objective();
+        objective.setDisplayNameUpdater(p -> "title for " + p.getName());
+
+        assertEquals("title for alice", objective.getDisplayName(player("alice")));
+        assertEquals("title for bob", objective.getDisplayName(player("bob")));
+    }
+
+    @Test
+    public void testStaticTitleClearsUpdater() {
+        ScoreboardObjective<String> objective = objective();
+        objective.setDisplayNameUpdater(p -> "conditional");
+
+        objective.setDisplayName("plain");
+
+        assertEquals("plain", objective.getDisplayName(player("alice")));
+    }
+
+    @Test
+    public void testGetDisplayNameWithoutPlayerIgnoresUpdater() {
+        ScoreboardObjective<String> objective = objective();
+        objective.setDisplayNameUpdater(p -> "conditional");
+
+        assertEquals("static", objective.getDisplayName());
+        assertEquals("conditional", objective.getDisplayName(player("alice")));
+    }
+}

--- a/src/test/java/me/catcoder/sidebar/SidebarLimitsTest.java
+++ b/src/test/java/me/catcoder/sidebar/SidebarLimitsTest.java
@@ -1,0 +1,56 @@
+package me.catcoder.sidebar;
+
+import me.catcoder.sidebar.protocol.ScoreboardPackets;
+import org.bukkit.ChatColor;
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class SidebarLimitsTest {
+
+    @Test
+    public void testLineLimitMatchesEntryAlphabet() {
+        assertEquals(ScoreboardPackets.COLORS.length, Sidebar.MAX_LINES_COUNT);
+        assertEquals(ChatColor.values().length, Sidebar.MAX_LINES_COUNT);
+
+        assertEquals(22, Sidebar.MAX_LINES_COUNT);
+    }
+
+    @Test
+    public void testEntryAlphabetCanCoverEveryRenderedLine() {
+        assertTrue("The entry alphabet must be able to fill the sidebar the client renders",
+                Sidebar.MAX_LINES_COUNT >= Sidebar.MAX_VISIBLE_LINES);
+    }
+
+    @Test
+    public void testEntriesAreUnique() {
+        Set<String> entries = new HashSet<>();
+
+        for (int index = 0; index < Sidebar.MAX_LINES_COUNT; index++) {
+            assertTrue("Duplicate team entry at index " + index,
+                    entries.add(ScoreboardPackets.COLORS[index].toString()));
+        }
+
+        assertEquals(Sidebar.MAX_LINES_COUNT, entries.size());
+    }
+
+    @Test
+    public void testEntriesRenderAsNothing() {
+       for (int index = 0; index < Sidebar.MAX_LINES_COUNT; index++) {
+            String entry = ScoreboardPackets.COLORS[index].toString();
+
+            assertEquals("Entry at index " + index + " is not a bare formatting code", 2, entry.length());
+            assertEquals("Entry at index " + index + " does not start with the colour char",
+                    ChatColor.COLOR_CHAR, entry.charAt(0));
+        }
+    }
+
+    @Test
+    public void testVisibleLimitIsTheVanillaSidebarHeight() {
+        assertEquals(15, Sidebar.MAX_VISIBLE_LINES);
+    }
+}

--- a/standalone-plugin/src/main/java/me/catcoder/sidebar/ProtocolSidebarPlugin.java
+++ b/standalone-plugin/src/main/java/me/catcoder/sidebar/ProtocolSidebarPlugin.java
@@ -1,5 +1,7 @@
 package me.catcoder.sidebar;
 
+import me.catcoder.sidebar.protocol.ProtocolConstants;
+import me.catcoder.sidebar.util.PlayerPredicates;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -21,12 +23,78 @@ public class ProtocolSidebarPlugin extends JavaPlugin implements Listener {
         sidebar.addLine("TEST");
         sidebar.addLine("TEST");
 
+        checkLineLimits();
+        checkConditionalTitle();
+
         Bukkit.getPluginManager().registerEvents(this, this);
+    }
+
+    private void checkLineLimits() {
+        Sidebar<String> probe = ProtocolSidebar.newMiniMessageSidebar("<gray>probe", this);
+
+        for (int i = 0; i < 10; i++) {
+            probe.addLine("plain " + i);
+        }
+        for (int i = 0; i < 12; i++) {
+            int index = i;
+            probe.addConditionalLine(player -> "legacy " + index,
+                    PlayerPredicates.clientVersionAtMost(ProtocolConstants.MINECRAFT_1_8));
+        }
+
+        getLogger().info("Registered " + probe.getLines().size() + " lines (expected 22)");
+
+        expectRejected("23rd line", () -> probe.addConditionalLine(p -> "overflow", p -> true));
+
+        Sidebar<String> plainProbe = ProtocolSidebar.newMiniMessageSidebar("<gray>probe2", this);
+        for (int i = 0; i < 15; i++) {
+            plainProbe.addLine("plain " + i);
+        }
+        expectRejected("16th always visible line", () -> plainProbe.addLine("overflow"));
+
+        // a freed slot must be reused instead of colliding with a surviving line
+        Sidebar<String> reuseProbe = ProtocolSidebar.newMiniMessageSidebar("<gray>probe3", this);
+        reuseProbe.addLine("a");
+        SidebarLine<String> middle = reuseProbe.addLine("b");
+        SidebarLine<String> last = reuseProbe.addLine("c");
+        reuseProbe.removeLine(middle);
+        SidebarLine<String> added = reuseProbe.addLine("d");
+
+        if (added.getIndex() == last.getIndex()) {
+            getLogger().severe("Slot collision: new line reuses the index of a live line");
+        } else {
+            getLogger().info("Slot reuse ok, new line got index " + added.getIndex()
+                    + ", surviving line holds " + last.getIndex());
+        }
+
+        probe.destroy();
+        plainProbe.destroy();
+        reuseProbe.destroy();
+    }
+
+    private void checkConditionalTitle() {
+        expectRejected("conditional title without otherwise(..)", () -> sidebar.setTitle(
+                ConditionalTitle.<String>create().when(p -> false, "<red>never")));
+
+        sidebar.setTitle(ConditionalTitle.<String>create()
+                .when(PlayerPredicates.clientVersionAtMost(ProtocolConstants.MINECRAFT_1_8), "<gold>Legacy")
+                .otherwise("<red>TEST</red>"));
+    }
+
+    private void expectRejected(String what, Runnable action) {
+        try {
+            action.run();
+            getLogger().severe("Expected " + what + " to be rejected, but it was accepted");
+        } catch (IllegalArgumentException | IllegalStateException e) {
+            getLogger().info("Rejected " + what + " as expected: " + e.getMessage());
+        }
     }
 
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent event) {
         Player player = event.getPlayer();
         sidebar.addViewer(player);
+
+        getLogger().info("Title for " + player.getName() + ": "
+                + sidebar.getObjective().getDisplayName(player));
     }
 }


### PR DESCRIPTION
Previously a setup like this:
- 5 conditional lines
- 12 normal lines

would fail, even if only one of the conditional lines would be active at all times.
Now it allows you to add up to 22, but if the active count exceed 15 it will be trimmed and a warning will be printed.

Also fixed performance Issues regarding ConditionalTitle.